### PR TITLE
Use crypto.randomBytes instead of Math.random, Log the string during test.

### DIFF
--- a/lib/randomstring.js
+++ b/lib/randomstring.js
@@ -4,17 +4,22 @@ var charsNumbers = '0123456789';
 var charsLower   = 'abcdefghijklmnopqrstuvwxyz';
 var charsUpper   = charsLower.toUpperCase();
 
+var crypto = require('crypto');
+
 var chars = charsNumbers + charsLower + charsUpper;
 
 exports.generate = function(length) {
 
-  if (!length) length = 32;
+  length = length || 32;
 
   var string = '';
 
-  for (var i = 0; i < length; i++) {
-    var randomNumber = Math.floor(Math.random() * chars.length);
-    string += chars.substring(randomNumber, randomNumber + 1);
+  while(string.length < length){
+    var bf = crypto.randomBytes(length);
+    for(var i = 0; i < bf.length; i++){
+      var index = bf.readUInt8(i)%chars.length;
+      string += chars.charAt(index);
+    }
   }
 
   return string;

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,9 @@ var random = require("..").generate
 describe("randomstring.generate()", function() {
 
   it("returns a string", function() {
-    assert.equal(typeof(random()), "string")
+    var rds = random();
+    assert.equal(typeof(rds), "string");
+    console.log("          String return: " + rds);
   })
 
   it("defaults to 32 characters in length", function() {


### PR DESCRIPTION
f3b2a55: Math.random is not cryptographically secure. Since that the number one
google result for "node random string" is this, it needs to be secure.
f81f839: To avoid returning "0000000000000000" and such.