### PR TITLE
Avoid problems if crypto.randomBytes throws an exception.

### DIFF
--- a/lib/randomstring.js
+++ b/lib/randomstring.js
@@ -15,7 +15,12 @@ exports.generate = function(length) {
   var string = '';
 
   while(string.length < length){
-    var bf = crypto.randomBytes(length);
+    var bf;
+    try {
+      bf = crypto.randomBytes(length);
+    } catch (e){
+      continue;
+    }
     for(var i = 0; i < bf.length; i++){
       var index = bf.readUInt8(i) % chars.length;
       string += chars.charAt(index);


### PR DESCRIPTION
[crypto.randomBytes](https://nodejs.org/api/crypto.html#crypto_crypto_randombytes_size_callback) can throw an error if not enough entropy is available. This is probably very rare, but it might be an issue if this is run too soon after boot, and it makes sense to catch the error and try again.