### PR TITLE
Consider lowercase letter o unreadable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ randomstring.generate({
 
 - `generate(options)`
   - `length` - the length of the random string. (default: 32) [OPTIONAL]
-  - `readable` - exclude poorly readable chars: 0OIl. (default: false) [OPTIONAL]
+  - `readable` - exclude poorly readable chars: 0OoIl. (default: false) [OPTIONAL]
   - `charset` - define the character set for the string. (default: 'alphanumeric') [OPTIONAL]
     - `alphanumeric` - [0-9 a-z A-Z]
     - `alphabetic` - [a-z A-Z]

--- a/lib/charset.js
+++ b/lib/charset.js
@@ -32,7 +32,7 @@ Charset.prototype.setType = function(type) {
 }
 
 Charset.prototype.removeUnreadable = function() {
-  var unreadableChars = /[0OIl]/g;
+  var unreadableChars = /[0OoIl]/g;
   this.chars = this.chars.replace(unreadableChars, '');
 }
 


### PR DESCRIPTION
In some environments, a lower case letter 'o' can be tricky to distinguish from an uppercase 'O' or numeric '0'.

I'd like propose scrapping all of them when `readable` is set to `true`.