### PR TITLE
Add lowercase 'o' to list of unreadable characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ randomstring.generate({
 
 - `generate(options)`
   - `length` - the length of the random string. (default: 32) [OPTIONAL]
-  - `readable` - exclude poorly readable chars: 0OIl. (default: false) [OPTIONAL]
+  - `readable` - exclude poorly readable chars: 0OoIl. (default: false) [OPTIONAL]
   - `charset` - define the character set for the string. (default: 'alphanumeric') [OPTIONAL]
     - `alphanumeric` - [0-9 a-z A-Z]
     - `alphabetic` - [a-z A-Z]

--- a/lib/charset.js
+++ b/lib/charset.js
@@ -32,7 +32,7 @@ Charset.prototype.setType = function(type) {
 }
 
 Charset.prototype.removeUnreadable = function() {
-  var unreadableChars = /[0OIl]/g;
+  var unreadableChars = /[0OoIl]/g;
   this.chars = this.chars.replace(unreadableChars, '');
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -50,7 +50,7 @@ describe("randomstring.generate(options)", function() {
   
   it("accepts readable option", function() {
     var testData = random({ length: testLength, readable: true });
-    var search = testData.search(/[0OIl]/g);
+    var search = testData.search(/[0OoIl]/g);
     assert.equal(search, -1);
   });
   


### PR DESCRIPTION
Small PR adding 'o' to the list of unreadable characters. A personal preference maybe, but I find 'o' confusing along with 0 and O. 

Updated README and tests to match, let me know what you think!