### PR TITLE
Using randombytes package instead of crypto 

### DIFF
--- a/lib/randomstring.js
+++ b/lib/randomstring.js
@@ -1,12 +1,12 @@
 "use strict";
 
-var crypto  = require('crypto');
+var randomBytes = require('randombytes');
 var Charset = require('./charset.js');
 
 function safeRandomBytes(length) {
   while (true) {
     try {
-      return crypto.randomBytes(length);
+      return randomBytes(length);
     } catch(e) {
       continue;
     }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "node": "*"
   },
   "dependencies": {
-    "array-uniq": "1.0.2"  
+    "array-uniq": "1.0.2",
+    "randombytes": "2.0.3"
   },
   "devDependencies": {
     "mocha": "^1.20.1"


### PR DESCRIPTION
using randombytes package instead of crypto as it helps in elimination of extra crypto libs inclusion if the code being used for the browser.

webpack include crypto code e.g. sha1 elliptic bn in the bundle if the crypto library is being used.
With this commit there is about 600K size reduction in bundle size for webpack.

with crypto:
<img width="1234" alt="crypto" src="https://cloud.githubusercontent.com/assets/874046/26578318/0141f556-454d-11e7-934a-65f700bb3b1a.png">

with randombytes:
<img width="1238" alt="randombytes" src="https://cloud.githubusercontent.com/assets/874046/26578329/0fa31fd0-454d-11e7-8462-a2a588fbc958.png">

