### PR TITLE
Fix browser support

### DIFF
--- a/lib/randomstring.js
+++ b/lib/randomstring.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var crypto = require('crypto');
 var randomBytes = require('randombytes');
 var Charset = require('./charset.js');
 
@@ -26,7 +25,7 @@ function processString(buf, initialString, chars, reqLen, maxByte) {
 }
 
 function getAsyncString(string, chars, length, maxByte, cb) {
-  crypto.randomBytes(length, function(err, buf) {
+  randomBytes(length, function(err, buf) {
     if (err) {
       // Since it is waiting for entropy, errors are legit and we shouldn't just keep retrying
       cb(err);


### PR DESCRIPTION
Use randomBytes instead of crypto.randomBytes

It seems that browser support was something wanted in this package (#26), but since 2a9af9b4ed09544c5a04b8993e3b606f9b904437 it is broken. This PR fixes it to make it compatible with webpack >= 5.