### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ randomstring.generate({
 randomstring.generate({
   charset: 'abc'
 }, cb);
-// >> "cb(generatedString) {}"
+// >> "cb(null, generatedString) {}"
 
 ```
 


### PR DESCRIPTION
There at [40 line](https://github.com/klughammer/node-randomstring/blob/5e8dabb97872e7f5b222f8a02d3a39f0ea4d9e81/README.md?plain=1#L40), it should be `(null, generatedString)` instead of `(generatedString)`, because it is misleading that it tells that generated string returns right away, when it doesn't. 
As it is in the [code](https://github.com/klughammer/node-randomstring/blob/5e8dabb97872e7f5b222f8a02d3a39f0ea4d9e81/lib/randomstring.js#L37).