### PR TITLE
fix: #34 #35 #37

### DIFF
--- a/lib/randomstring.js
+++ b/lib/randomstring.js
@@ -3,13 +3,27 @@
 var randomBytes = require('randombytes');
 var Charset = require('./charset.js');
 
-function safeRandomBytes(length) {
-  while (true) {
-    try {
-      return randomBytes(length);
-    } catch(e) {
-      continue;
+
+function unsafeRandomBytes(length) {
+  var stack = [];
+  for (var i = 0; i < length; i++) {
+    stack.push(Math.floor(Math.random() * 255));
+  }
+
+  return {
+    length,
+    readUInt8: function (index) {
+      return stack[index];
     }
+  };
+}
+
+function safeRandomBytes(length) {
+  try {
+    return randomBytes(length);
+  } catch (e) {
+    /* React/React Native Fix + Eternal loop removed */
+    return unsafeRandomBytes(length);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "randomstring",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "author": "Elias Klughammer <elias@klughammer.com> (http://www.klughammer.com)",
   "description": "A module for generating random strings",
   "homepage": "https://github.com/klughammer/node-randomstring",
@@ -17,7 +17,7 @@
     "randombytes": "2.0.3"
   },
   "devDependencies": {
-    "mocha": "^1.20.1"
+    "mocha": "^10.0.0"
   },
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Applications using React does not have access to Crypto/Buffer node modules, i did implemented my own generator of bytes. This pull does not try to be as secure as `crypto randomBytes`. The new implementation just will be executed if the standard function does not works.

Tests: 20/20 (using the new implementation).
Tested with React Native.