### PR TITLE
Fix Unexpected behavior of length option

### DIFF
--- a/lib/randomstring.js
+++ b/lib/randomstring.js
@@ -46,7 +46,7 @@ exports.generate = function(options, cb) {
 
   // Handle options
   if (typeof options === 'object') {
-    length = options.length || 32;
+    length = typeof options.length === 'number' ? options.length : 32;
 
     if (options.charset) {
       charset.setType(options.charset);

--- a/test/index.js
+++ b/test/index.js
@@ -24,10 +24,12 @@ describe("randomstring.generate(options)", function() {
 
   it("accepts length as an optional first argument", function() {
     assert.equal(random(10).length, 10);
+    assert.equal(random(0).length, 0);
   });
 
   it("accepts length as an option param", function() {
     assert.equal(random({ length: 7 }).length, 7);
+    assert.equal(random({ length: 0 }).length, 0);
   });
 
   it("accepts length as an option param async", function(done) {


### PR DESCRIPTION
Hello, I've noticed the result of `generate(0)` and `generate({length: 0})` are different. This is due to JavaScript behavior of considering `0` as `falsy`, resulting this module to return defaults length instead (32).

https://github.com/klughammer/node-randomstring/blob/5e8dabb97872e7f5b222f8a02d3a39f0ea4d9e81/lib/randomstring.js#L49

How to Reproduce:
```
var randomstring = require("randomstring");
var caseA = randomstring.generate(0);
var caseB = randomstring.generate({length: 0});
assert(caseA == caseB);
```

I hope this PR can be merged with #38 as the mocha is outdated.